### PR TITLE
Remove feature(attr_literals)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 //! Attept to write screenfetch in Rust
-#![feature(attr_literals)]
 
 extern crate clap;
 #[macro_use] extern crate prettytable;


### PR DESCRIPTION
This prevents building on stable but can be removed now that its been stabilised:

https://github.com/rust-lang/rust/pull/53044